### PR TITLE
[FIX] 이미지 파일 미리보기를 추가하라, 공통 네비게이션 바를 사용하라

### DIFF
--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,12 +1,20 @@
 import React, { useState } from "react";
 import { loadItem } from "../common/storage";
 import { SubNavBar } from "../components/navBar/SubNavBar";
+
 import styles from "../style/postPageStyle.module.scss";
+// import styles from "../style/navFooterStyle.module.scss";
 import { ReactComponent as Icon_ImageAdd } from "../assets/gray_image_add.svg";
+import { ReactComponent as Icon_ChevronLeft } from "../assets/white_chevron_left.svg";
+import { ReactComponent as Icon_CheckSqure } from "../assets/white_check_squre.svg";
 
 export const PostPage = () => {
   const keyowrd = loadItem("postKeyword");
+  const [textLength, setTextLength] = useState(0);
+  const [textareaBox, setTextareaBox] = useState("");
   const [imageUrl, setImageUrl] = useState("");
+  const [imgBox, setImgBox] = useState(false);
+  const [imgIcon, setImgIcon] = useState(true);
   const [postKeyword, setPostKeyword] = useState(keyowrd);
 
   const today = new Date();
@@ -15,13 +23,24 @@ export const PostPage = () => {
   const handleChangeImage = (e) => {
     if (e.target.files[0]) {
       setImageUrl(URL.createObjectURL(e.target.files[0]));
+      setImgIcon(false);
+      setImgBox(true);
     }
     const target = e.currentTarget;
     const files = target.files[0];
-    console.log(target);
-    console.log(files);
   };
 
+  const handleImgEdit = () => {
+    if (window.confirm("사진을 바꾸시겠습니까?")) {
+      setImgIcon(true);
+      setImageUrl("");
+      setImgBox(false);
+    }
+  };
+
+  const handlePostAdd = () => {
+    console.log("작성페이지 네비게이션 추가버튼");
+  };
   return (
     <>
       {/* {keyowrd === "ToonDiary" ? (
@@ -30,7 +49,12 @@ export const PostPage = () => {
         <div>새 툰 만들기 컴포넌트</div>
       )} */}
       {/* 어떤 경로로 들어오느냐에 따라서 리스트를 작성 / 다이어리 생성할건지 */}
-      <SubNavBar children="( 일기장 제목 ) 툰 일기" />
+
+      <SubNavBar
+        children="( 일기장 제목 ) 툰 일기"
+        checkbox={true}
+        handleFunc={handlePostAdd}
+      />
 
       <div className={styles.postBox}>
         <div className={styles.subContent}>
@@ -43,7 +67,7 @@ export const PostPage = () => {
           <div className={styles.inputBox}>
             <input
               type="text"
-              maxlength="20"
+              maxLength="20"
               placeholder={`부제목을 입력해주세요`}
             />
           </div>
@@ -53,24 +77,40 @@ export const PostPage = () => {
             className={styles.textarea}
             maxLength="100"
             placeholder="오늘의 툰을 설명해주세요"
+            onChange={(e) => {
+              setTextLength(e.target.value.length);
+              setTextareaBox(e.target.value);
+            }}
           />
-          <p className={styles.textNumbering}>81/100</p>
+          <p className={styles.textNumbering}>{textLength}/100</p>
         </div>
+
         <div className={styles.imgBox}>
-          <div>
-            <img src={imageUrl} />
-          </div>
-          {/* 이미지클릭했을 때 다시 바꿀 수 있게 여튼 다시해봐 */}
-          <p className="fileLoad">
-            <label htmlFor="file">오늘의 툰을 올려주세요</label>
-          </p>
-          <input
-            type="file"
-            id="file"
-            accept="image/*"
-            required
-            onChange={handleChangeImage}
-          />
+          {imgBox ? (
+            <div>
+              <img src={imageUrl} onClick={handleImgEdit} />
+            </div>
+          ) : null}
+          {imgIcon ? (
+            <>
+              <p className={styles.fileLoad}>
+                <label htmlFor="file">
+                  <p>
+                    <Icon_ImageAdd />
+                  </p>
+                  <p>오늘의 툰을 올려주세요</p>
+                </label>
+              </p>
+              <input
+                className="fileInput"
+                type="file"
+                id="file"
+                accept="image/*"
+                required
+                onChange={handleChangeImage}
+              />
+            </>
+          ) : null}
         </div>
       </div>
     </>

--- a/src/style/postPageStyle.module.scss
+++ b/src/style/postPageStyle.module.scss
@@ -3,7 +3,6 @@
 .postBox {
   padding-top: 60px;
   box-sizing: border-box;
-  border: 1px solid red;
 }
 
 .subContent {
@@ -28,7 +27,6 @@
   }
   .inputBox > input {
     width: 380px;
-    // border: 1px solid red;
   }
   input::placeholder {
     font-size: $middleSize;
@@ -45,6 +43,7 @@
     resize: none;
     font-size: $basicSize;
     overflow: hidden;
+
     // 서로 다른 그라디언트로 겹치게 해서 줄을 만드는 듯
     background-attachment: local;
     background-image: linear-gradient(to right, white 25px, transparent 25px),
@@ -73,6 +72,7 @@ textarea::placeholder {
 }
 
 .imgBox {
+  position: relative;
   height: 500px;
   background-color: $BGgray;
   & > div {
@@ -80,8 +80,27 @@ textarea::placeholder {
     border-radius: 8px;
     img {
       width: 100%;
+      height: 100%;
       object-fit: cover;
+      background-size: cover;
     }
+  }
+  .fileLoad {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    color: $darkgray;
+    cursor: pointer;
+  }
+  input[type="file"] {
+    /* 파일 필드 숨기기 */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
- input 태그의 file을 사용하여 이미지 미리보기를 구현하였다.
- 이미지를 클릭하면 다시 수정할 수 있도록 설정해놓았다.
- 서브 네비바 컴포넌트에 상세페이지에서 사용할 내용을 props로 넘겼다