### PR TITLE
[ADD] 상세페이지를 구현하라.

### DIFF
--- a/src/components/DiaryMypage.jsx
+++ b/src/components/DiaryMypage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from '../styles/homePageStyle.module.scss';
 import { ReactComponent as Icon_DiaryAdd } from '../assets/black_diaryadd.svg';
-import { DiaryItem } from './DiaryItem';
+import { HomeMiniDiary } from './HomeMiniDiary';
 
 export const DiaryMypage = () => {
   const navigate = useNavigate();
@@ -23,8 +23,8 @@ export const DiaryMypage = () => {
           만들기
         </p>
       </div>
-      <DiaryItem />
-      <DiaryItem />
+      <HomeMiniDiary />
+      <HomeMiniDiary />
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <button
           onClick={() => {

--- a/src/components/DiaryNew.jsx
+++ b/src/components/DiaryNew.jsx
@@ -1,13 +1,13 @@
-import React from "react";
-import { DiaryItem } from "./DiaryItem";
+import React from 'react';
+import { HomeMiniDiary } from './HomeMiniDiary';
 
 export const DiaryNew = () => {
   // 각자 페이지에 맞는 get요청하기
   return (
     <>
       <div>DiaryNew</div>
-      <DiaryItem />
-      <DiaryItem />
+      <HomeMiniDiary />
+      <HomeMiniDiary />
     </>
   );
 };

--- a/src/components/DiarySubscribe.jsx
+++ b/src/components/DiarySubscribe.jsx
@@ -1,13 +1,13 @@
-import React from "react";
-import { DiaryItem } from "./DiaryItem";
+import React from 'react';
+import { HomeMiniDiary } from './HomeMiniDiary';
 
 export const DiarySubscribe = () => {
   // 각자 페이지에 맞는 get요청하기
   return (
     <>
       <div>DiarySubscribe</div>
-      <DiaryItem />
-      <DiaryItem />
+      <HomeMiniDiary />
+      <HomeMiniDiary />
     </>
   );
 };

--- a/src/components/HomeMiniDiary.jsx
+++ b/src/components/HomeMiniDiary.jsx
@@ -1,9 +1,9 @@
-import React from "react";
-import styles from "../styles/homePageStyle.module.scss";
-import Icon_subscribe from "../assets/black_subscribe.svg";
-import { Link } from "react-router-dom";
+import React from 'react';
+import styles from '../styles/homePageStyle.module.scss';
+import Icon_subscribe from '../assets/black_subscribe.svg';
+import { Link } from 'react-router-dom';
 
-export const DiaryItem = () => {
+export const HomeMiniDiary = () => {
   return (
     <Link to="/detail/1">
       <div className={styles.diaryItem}>

--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { useParams } from 'react-router-dom';
 
 import { localLoadItem } from '../service/storage.js';
-import { ModalDiarySelectForm } from './ModalForm';
+import { ModalDiarySelectForm } from './common/ModalForm';
 import { SubNavBar } from './navBar/SubNavBar';
 import { useInput } from '../hooks/useInput';
 import { useCreatePost } from '../service/api.js';
@@ -17,16 +17,19 @@ export const PostList = () => {
 
   const [showModal, setShowModal] = useState(false);
   const [imgContain, setImgContain] = useState(false);
-
   const [imageUrl, setImageUrl] = useState('');
+  const [img, setImg] = useState('');
+
   const [date, setDate] = useState('');
-  const [subTitle, onChangeSubTitle] = useInput();
+  const [title, onChangeTitle] = useInput();
   const [textarea, onChangeTextarea] = useInput();
 
   const handleChangeImage = (e) => {
     if (e.target.files[0]) {
       setImageUrl(URL.createObjectURL(e.target.files[0]));
       setImgContain(true);
+      const files = e.currentTarget.files[0];
+      setImg(files);
     }
   };
 
@@ -39,10 +42,10 @@ export const PostList = () => {
 
   const { mutate: createPost } = useCreatePost();
   const clickCreatePost = () => {
-    // console.log(imageUrl, subTitle, date, textarea);
+    console.log(imageUrl, title, date, textarea);
     const newPost = {
-      img: imageUrl,
-      subTitle,
+      img,
+      title,
       date,
       content: textarea,
     };
@@ -90,16 +93,18 @@ export const PostList = () => {
           </div>
           <div className={styles.inputBox}>
             <input
+              value={title || ''}
               type="text"
               maxLength="20"
-              placeholder={`부제목을 입력해주세요`}
-              onChange={onChangeSubTitle}
+              placeholder={`툰 제목을 입력해주세요`}
+              onChange={onChangeTitle}
             />
           </div>
         </div>
 
         <div className={styles.textareaBox}>
           <textarea
+            value={textarea || ''}
             className={styles.textarea}
             maxLength="100"
             placeholder="오늘의 툰을 설명해주세요"

--- a/src/components/element/DiaryListItem.jsx
+++ b/src/components/element/DiaryListItem.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from '../../styles/detailPageStyle.module.scss';
+import { MiddleNavBar } from '../navBar/MiddleNavBar';
+
+export const DiaryListItem = ({ diaryList }) => {
+  return (
+    <>
+      {diaryList.map((list) => {
+        return (
+          <div className={styles.detailList}>
+            <div className={styles.ListSubTitle}>
+              <p>{list.date}</p>
+              <p>{list.title}</p>
+            </div>
+            <div className={styles.imgBox}>
+              <img src={list.img} />
+            </div>
+            <MiddleNavBar isCover={false} />
+            <div className={styles.diaryTitle}>
+              <span>{list.content}</span>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/components/navBar/MiddleNavBar.jsx
+++ b/src/components/navBar/MiddleNavBar.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { localSaveItem } from '../../service/storage.js';
-import { ModalEditDeleteForm, ModalMessageForm } from '../ModalForm';
+import { ModalEditDeleteForm, ModalMessageForm } from '../common/ModalForm';
 import styles from '../../styles/navFooterStyle.module.scss';
 
 import {
@@ -18,25 +18,25 @@ import {
 } from '../../assets/index';
 import { useDeleteDiary } from '../../service/api.js';
 
-export const MiddleNavBar = (diaryTitle) => {
+export const MiddleNavBar = ({ diaryTitle, isCover }) => {
+  console.log(diaryTitle);
+  console.log(isCover);
   const navigate = useNavigate();
   const { id } = useParams();
   const [showModal, setShowModal] = useState(false);
 
-  const [isCover, setIsCover] = useState(false);
   const [isLike, setIsLike] = useState(false);
 
   const handleDiaryEdit = () => {
     console.log('다이어리 수정');
   };
 
-  
-  const {mutate : deleteDiary} = useDeleteDiary()
+  const { mutate: deleteDiary } = useDeleteDiary();
   const handleDiaryDelete = () => {
     console.log('다이어리 삭제');
-    deleteDiary(id)
+    deleteDiary(id);
   };
-  // console.log(diaryTitle);
+
   return (
     <div className={styles.middleNavBar}>
       <div className={styles.middleLeftBar}>
@@ -51,6 +51,7 @@ export const MiddleNavBar = (diaryTitle) => {
 
           {isCover ? (
             <div
+              className={styles.iconMargin}
               onClick={() => {
                 navigate('/subscribe');
               }}
@@ -61,7 +62,7 @@ export const MiddleNavBar = (diaryTitle) => {
               <span>1명 구독중</span>
             </div>
           ) : (
-            <div className={styles.listPage}>
+            <div className={styles.iconMargin}>
               <p
                 onClick={() => {
                   navigate('/comment');

--- a/src/pages/DetailPage.jsx
+++ b/src/pages/DetailPage.jsx
@@ -1,27 +1,38 @@
-import React, { useEffect, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import React from 'react';
+import { useQuery } from 'react-query';
 import styles from '../styles/detailPageStyle.module.scss';
 
-import { FooterBar } from '../components/navBar/FooterBar';
+import Lottie from 'lottie-react';
+import loading from '../assets/lottie/loading.json';
+
 import { MiddleNavBar } from '../components/navBar/MiddleNavBar';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getDetailDiaryApi } from '../service/api';
-import { localLoadItem } from '../service/storage';
+import { DiaryListItem } from '../components/element/DiaryListItem';
 
 export const DetailPage = () => {
-  const QueryClient = useQueryClient();
   const navigate = useNavigate();
   const { id } = useParams();
 
   const { data, isLoading } = useQuery(['detail', id], () => {
     return getDetailDiaryApi(id);
   });
+
   const diaryData = data?.data.data;
   const diaryList = diaryData?.diaryList;
-  const userProfile = localLoadItem();
+  console.log(diaryData?.title);
+
   const moveSearchPage = (item) => {
     navigate('/search');
   };
+
+  if (isLoading) {
+    return (
+      <>
+        <Lottie animationData={loading} />
+      </>
+    );
+  }
 
   return (
     <div className={styles.detail}>
@@ -34,14 +45,13 @@ export const DetailPage = () => {
           <div className={styles.diaryInfoBox}>
             <div>
               <img src="/img/user.jpg" />
-              {/* <img src="/img/user.jpg" /> */}
               <div>
                 <p>하루의 생각</p>
                 <p>우리는 매일 생각하며 살아간다</p>
               </div>
             </div>
           </div>
-          <MiddleNavBar diaryTitle={diaryData?.title} />
+          <MiddleNavBar diaryTitle={diaryData?.title} isCover={true} />
 
           <div className={styles.diaryTitle}>
             <p>{diaryData?.title}</p>
@@ -72,27 +82,7 @@ export const DetailPage = () => {
             </span>
           </div>
         </div>
-        {/* 
-        {diaryList?.map((l) => {
-          //
-        })} */}
-        <div className={styles.detailList}>
-          <div className={styles.ListSubTitle}>
-            <p>2023년 2월 6일</p>
-            <p>부제목은 10글자로제한</p>
-          </div>
-          <div className={styles.imgBox}>
-            <img src="/img/ee.jpg" />
-          </div>
-          <MiddleNavBar />
-          <div className={styles.diaryTitle}>
-            <span>
-              우리는 매일 생각하며 살아간다 동해물과 백두산이 마르고 닳도록 하나님이 보우하사
-              우리나라만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세 우리나라만세
-              무궁화 삼천리 화려
-            </span>
-          </div>
-        </div>
+        <DiaryListItem diaryList={diaryList} />;
       </div>
     </div>
   );

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,9 +1,9 @@
-//Lottie style
-import Lottie from 'lottie-react';
 import { useNavigate } from 'react-router-dom';
-import badpage from '../assets/lottie/badpage.json';
 import { localSaveItem } from '../service/storage';
 import styles from '../styles/global.module.scss';
+
+import Lottie from 'lottie-react';
+import badpage from '../assets/lottie/badpage.json';
 
 export const NotFound = () => {
   const navigate = useNavigate();

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -3,16 +3,16 @@ import { useMutation, useQueryClient } from 'react-query';
 import { localLoadItem, localSaveItem } from './storage';
 
 const loginbaseURL = axios.create({
-  // baseURL: 'https://jm.rgngr.shop/api',
-  baseURL: 'http://3.38.98.211:8080/api',
+  baseURL: 'https://jm.rgngr.shop/api',
+  // baseURL: 'http://3.38.98.211:8080/api',
   headers: {
     'Access-Control-Allow-Origin': '*',
   },
 });
 
 const baseURL = axios.create({
-  // baseURL: 'https://jm.rgngr.shop/api',
-  baseURL: 'http://3.38.98.211:8080/api',
+  baseURL: 'https://jm.rgngr.shop/api',
+  // baseURL: 'http://3.38.98.211:8080/api',
   headers: {
     'Access-Control-Allow-Origin': '*',
   },
@@ -65,14 +65,16 @@ export const signupApi = async (payload) => {
   });
 };
 
+// 다이어리 folder + list = get
 export const getDetailDiaryApi = async (id) => {
   const res = await baseURL.get(`/folders/${id}`);
   return res;
 };
 
-// 포스트 다이어리 생성
+// 다이어리 folder 생성
 const createPostCoverApi = async (payload) => {
   const { img, open, title, hashtags } = payload;
+  console.log(payload);
   const formData = new FormData();
   formData.append('img', img);
   formData.append('open', open);
@@ -103,36 +105,7 @@ export const useAddPostCover = () => {
   });
 };
 
-// 다이어리 리스트 생성
-const createPostListApi = async ({ id, newPost }) => {
-  const { img, content, subTitle, date } = newPost;
-  const formData = new FormData();
-  formData.append('img', img);
-  formData.append('content', content);
-  formData.append('subTitle', subTitle);
-  formData.append('date', date);
-
-  const res = await baseURL
-    .post(`folders/${id}/diaries`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    })
-    .then((res) => {
-      console.log(res);
-      window.location.replace('/home/mydiary');
-    });
-  // return res;
-};
-export const useCreatePost = () => {
-  const QueryClient = useQueryClient();
-  return useMutation(createPostListApi, {
-    onSuccess: () => {
-      QueryClient.invalidateQueries(['detail']);
-    },
-  });
-};
-
+// 다이어리 folder 삭제
 const delelteDiaryApi = async (id) => {
   const res = await baseURL.delete(`/folders/${id}`);
   console.log(res);
@@ -146,6 +119,39 @@ export const useDeleteDiary = () => {
     },
     onError: (data) => {
       alert(data?.response.data.statusMsg);
+    },
+  });
+};
+
+// 다이어리 list 생성
+const createPostListApi = async ({ id, newPost }) => {
+  console.log(newPost);
+  const { img, content, title, date } = newPost;
+  const formData = new FormData();
+  formData.append('img', img);
+  formData.append('content', content);
+  formData.append('title', title);
+  formData.append('date', date);
+
+  const res = await baseURL
+    .post(`folders/${id}/diaries`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    .then((res) => {
+      console.log(res);
+      window.location.replace('/home/mydiary');
+    })
+    .catch((res) => {
+      console.log(res);
+    });
+};
+export const useCreatePost = () => {
+  const QueryClient = useQueryClient();
+  return useMutation(createPostListApi, {
+    onSuccess: () => {
+      QueryClient.invalidateQueries(['detail']);
     },
   });
 };


### PR DESCRIPTION
- 상세페이지의 list의 내용을 get하는 기능을 완성하였다.
- list의 내용은 배열이므로 컴포넌트를 추가하여 상세페이지와 연결하였다.
- 메인페이지의 전체 다이어리 리스트와 상세페이지 리스트가 헷갈려 컴포넌트 이름을 변경하였다.
- 상세페이지의 cover와 list의 middleNav의 내용이 다르기 때문에 해당 state값에 따라 내용을 동적으로 변경해주었다.
- query로 불러오는 데이터의 상태가 loading일 때 보여주는 view를 로티 이미지로 대체하였다.